### PR TITLE
Add pyproject.toml for building / installing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Running python ${{ matrix.python-version }} on ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v3.2.0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Print Python Version
+      run: python --version --version && which python
+
+    - name: Update pip, setuptools + wheels
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+
+    - name: Install deps via requirements + module via pyproject.toml
+      run: |
+        python -m pip install -r requirements.txt
+        python -m pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
 ARG PY_VERSION=3.9
 
+# Build container
 FROM python:${PY_VERSION} as base
-
 FROM base as builder
 ARG PY_VERSION
 
-RUN mkdir /install
+RUN mkdir /install /src
 WORKDIR /install
 RUN pip install --target="/install" --upgrade pip setuptools wheel
-ADD requirements.txt /install
+COPY requirements.txt /install
 RUN pip install --target="/install" -r requirements.txt
+COPY README.md /src
+COPY cogs /src
+COPY models /src
+COPY gpt3discord.py /src
+COPY pyproject.toml /src
+RUN pip install --target="/install" /src
 
-
+# Copy minimal to main image (to keep as small as possible)
 FROM python:${PY_VERSION}-slim
-
 ARG PY_VERSION
-
 COPY --from=builder /install /usr/local/lib/python${PY_VERSION}/site-packages
-COPY cogs /usr/local/lib/python${PY_VERSION}/site-packages/cogs
-COPY models /usr/local/lib/python${PY_VERSION}/site-packages/models
-COPY main.py /bin/gpt3discord
-
+COPY gpt3discord.py /bin/gpt3discord
 CMD ["python3", "/bin/gpt3discord"]

--- a/README.md
+++ b/README.md
@@ -99,27 +99,23 @@ After login, we need to install the various dependencies that the bot needs. To 
     6  sudo apt-get update
     7  sudo apt install software-properties-common
     8  sudo add-apt-repository ppa:deadsnakes/ppa
-    9  sudo apt install python3.9
-# This command below should return "Python 3.9.x", if it is working. Otherwise, don't proceed.
-   10  python3.9 --version 
-   11  ls
-   13  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-   14  python3.9 get-pip.py
+    9  sudo apt install python3.9 python3.9-pip
 # Install project dependencies
-   15  python3.9 -m pip install -r requirements.txt
-   16  ls
+   10 python3.9 -m pip install -r requirements.txt
+   11 python3.9 -m pip install .
+   12 ls
 # Copy the sample.env file into a regular .env file. `DEBUG_GUILD` can be found by right-clicking your server and choosing "Copy ID". Similarly, `DEBUG_CHANNEL` can be found by right-clicking your debug channel.
-   17  cp sample.env .env
+   13  cp sample.env .env
 # The command below is used to edit the .env file and to put in your API keys. You can right click within the
 # editor after running this command to paste. When you are done editing, press CTRL + X, and then type Y, to save.
-   18  nano .env
-   19  ls
+   14  nano .env
+   15  ls
 # Run the bot using [screen](https://www.gnu.org/software/screen/manual/screen.html) to keep it running after you disconnect from your SSH session:
-   20  screen python3.9 main.py
+   16  screen gpt3discord
 
 # Hit `Ctrl+a` then `d` to detach from the running bot.
 # The bot's screen session can be reattached:
-   21  screen -r
+   17  screen -r
 ```
 
 ## Docker Installation

--- a/gpt3discord.py
+++ b/gpt3discord.py
@@ -14,6 +14,7 @@ from models.message_model import Message
 from models.openai_model import Model
 from models.usage_service_model import UsageService
 
+__version__ = "2022.12"
 load_dotenv()
 import os
 
@@ -70,8 +71,7 @@ async def main():
 
 
 # Run the bot with a token taken from an environment file.
-if __name__ == "__main__":
-
+def init():
     PID_FILE = "bot.pid"
     if os.path.exists(PID_FILE):
         print("Process ID file already exists")
@@ -93,3 +93,7 @@ if __name__ == "__main__":
         os.remove(PID_FILE)
     finally:
         sys.exit(0)
+
+
+if __name__ == "__main__":
+    sys.exit(init())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "gpt3discord"
+description = "A Chat GPT Discord bot"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+keywords = []
+authors = [
+  { name = "Kaveen Kumarasinghe", email = "contact@kaveenk.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.9",
+]
+dependencies = [
+  "asgiref",
+  "openai",
+  "Pillow",
+  "py-cord",
+  "python-dotenv",
+  "requests",
+  "transformers",
+]
+dynamic = ["version"]
+[project.scripts]
+gpt3discord = "gpt3discord:init"
+[project.urls]
+Documentation = "https://github.com/Kav-K/GPT3Discord/#readme"
+Issues = "https://github.com/Kav-K/GPT3Discord/issues"
+Source = "https://github.com/Kav-K/GPT3Discord"
+
+[tool.hatch.version]
+path = "gpt3discord.py"
+
+[tool.hatch.build]
+include = [
+  "cogs/*.py",
+  "models/*.py",
+  "gpt3discord.py",
+]
+
+#[tool.hatch.build.targets.sdist]
+#packages = ["cogs", "gpt3discord.py", "models"]
+
+#[tool.hatch.build.targets.wheel]
+#packages = ["cogs", "gpt3discord.py", "models"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["39"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-py-cord==2.3.2
+asgiref==3.6.0
+openai==0.25.0
 Pillow==9.3.0
+py-cord==2.3.2
 python-dotenv==0.21.0
 requests==2.28.1
 transformers==4.25.1


### PR DESCRIPTION
- Add a pyproject.toml to install all modules and packages
  - Use hatch to build + install
  - Still only claim support for 3.9
  - We don't specify versions in pyproject.toml on purpose so people can have some flexibility there
    - If they want the tested pinned versions they can use requirements.txt like Docker + CI does ...
  - This will allow the package to be uploaded to PyPI if you'd like now :)
- `git mv main.py gpt3discord.py` as main.py is to common (incase someone installs to shared python env)
  - Move initalization code into a init() function to have entry point script call
- Update `Dockerfile` to install via pyproject.toml
  - Both docker + build CI install requirements.txt so we get the known versions of dependencies that work
- Update README for less steps now in installing
  - Side note, we will have to track versions now and increment as we see fit - I'd like to discuss using GitHub releases here ...
- Sort requirements.txt to be alphabetical ...

Test:
- Add python 3.9 CI to install our module
  - Paves the way to add more CI to help me test the module works in 3.11
- Build in a local venv
  - `python3.9 -m venv /tmp/foovenv`
  - `/tmp/foovenv/bin/pip install -r requirements.txt`
  - `/tmp/foovenv/bin/pip install .`
- Build in docker
  - `docker build -t gpt3discord .`