### PR TITLE
Add PyPI Uploading

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -1,0 +1,34 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    name: sdist + pure wheel
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up latest Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "*"
+
+      - name: Install latest pip, build, twine
+        run: |
+          python -m pip install --upgrade --disable-pip-version-check pip
+          python -m pip install --upgrade build twine
+
+      - name: Build wheel and source distributions
+        run: python -m build
+
+      - name: Upload to PyPI via Twine
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: twine upload --verbose -u '__token__' dist/*


### PR DESCRIPTION
- Add a GitHub action to publish a source distribution (sdist) + wheel (binary package) to PyPI
  - PyPI will create the package on upload unlike Docker Hub

This will need a PYPI_TOKEN secret added. Please go register @ pypi.org make a token please + add to GitHub secrets
- Later on you could swap the token locked to this one module if you want to be security concious
  - (Please do this before merging)

Fixes #25