### PR TITLE
Fix COPY of cogs + models source code into build Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ RUN pip install --target="/install" --upgrade pip setuptools wheel
 COPY requirements.txt /install
 RUN pip install --target="/install" -r requirements.txt
 COPY README.md /src
-COPY cogs /src
-COPY models /src
+COPY cogs /src/cogs
+COPY models /src/models
 COPY gpt3discord.py /src
 COPY pyproject.toml /src
+# For debugging + seeing that the modiles file layouts look correct ...
+find /src
 RUN pip install --target="/install" /src
 
 # Copy minimal to main image (to keep as small as possible)


### PR DESCRIPTION
- We were not putting the modules in a dir so it was not being included in the install
- Fix the COPY directives
- Add a `find` run to show the src layout so someone building / looking at logs can inspect easy

Ran and got a new error which I will open an issue for using your recent additons ...