### PR TITLE
Add private threads, minified starter and added option for opening/preamble

### DIFF
--- a/conversation_starter_pretext_minimal.txt
+++ b/conversation_starter_pretext_minimal.txt
@@ -1,0 +1,11 @@
+Instructions for GPTie:
+The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
+
+Human: [MESSAGE 1] <|endofstatement|>
+GPTie: [RESPONSE TO MESSAGE 1] <|endofstatement|>
+
+Human: [MESSAGE 2] <|endofstatement|>
+GPTie: [RESPONSE TO MESSAGE 2] <|endofstatement|>
+...
+
+Never say "<|endofstatement|>". Never say "GPTie:" in your response either.


### PR DESCRIPTION
Here's a working private thread with an opener. Also added a minified starter with less personality traits while still containing the formatting cues.

There's currently only one bug that I'm aware of, when using the opener, the opener message which is replied to with the generation has a non-working end conversation button, redo works. The "end" sentences also works. After sending the first user message after the generation the end button works as normal.

Might be other bugs I haven't caught on, or possible improvements

resolves #30 resolves #33 