### PR TITLE
Replace 'Human:' in prompt with actual username

### DIFF
--- a/cogs/gpt_3_commands_and_converser.py
+++ b/cogs/gpt_3_commands_and_converser.py
@@ -503,6 +503,12 @@ class GPT3ComCon(commands.Cog, name="GPT3ComCon"):
         new_prompt = prompt + "\nGPTie: "
         from_context = isinstance(ctx, discord.ApplicationContext)
 
+        # Replace 'Human:' with the user's name
+        try:
+             new_prompt = new_prompt.replace("Human:", ctx.author.name + ":")
+        except AttributeError:
+            pass
+
         try:
             tokens = self.usage_service.count_tokens(new_prompt)
 


### PR DESCRIPTION
Replace 'Human:' in prompt with actual username. 
- makes for more natural summaries
- makes for more natural conversation
- encourages bot to act as one person to another, instead of as bot to a human.