### PR TITLE
Changed conversations to be keyed by thread allowing multi user conversations

### DIFF
--- a/cogs/gpt_3_commands_and_converser.py
+++ b/cogs/gpt_3_commands_and_converser.py
@@ -482,7 +482,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         )
         new_conversation_history.append(summarized_text)
         new_conversation_history.append(
-            "\nContinue the conversation, paying very close attention to things Human told you, such as their name, and personal details.\n"
+            "\nContinue the conversation, paying very close attention to things <username> told you, such as their name, and personal details.\n"
         )
         # Get the last entry from the user's conversation history
         new_conversation_history.append(
@@ -516,15 +516,15 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
 
                 edited_content = after.content
                 # If the user is conversing, we need to get their conversation history, delete the last
-                # "Human:" message, create a new Human: section with the new prompt, and then set the prompt to
+                # "<username>:" message, create a new <username>: section with the new prompt, and then set the prompt to
                 # the new prompt, then send that new prompt as the new prompt.
                 if after.channel.id in self.conversation_threads:
-                    # Remove the last two elements from the history array and add the new Human: prompt
+                    # Remove the last two elements from the history array and add the new <username>: prompt
                     self.conversation_threads[
                         after.channel.id
                     ].history = self.conversation_threads[after.channel.id].history[:-2]
                     self.conversation_threads[after.channel.id].history.append(
-                        f"\nHuman: {after.content}<|endofstatement|>\n"
+                        f"\n{after.author.name}: {after.content}<|endofstatement|>\n"
                     )
                     edited_content = "".join(
                         self.conversation_threads[after.channel.id].history
@@ -971,7 +971,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                 self.awaiting_responses.append(user_id_normalized)
 
                 self.conversation_threads[thread.id].history.append(
-                    "\nHuman: " + opener + "<|endofstatement|>\n"
+                    f"\n'{ctx.user.name}': {opener} <|endofstatement|>\n"
                 )
 
                 self.conversation_threads[thread.id].count += 1

--- a/cogs/gpt_3_commands_and_converser.py
+++ b/cogs/gpt_3_commands_and_converser.py
@@ -608,7 +608,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                 original_message[message.author.id] = message.id
 
                 self.conversation_threads[message.channel.id].history.append(
-                    "\nHuman: " + prompt + "<|endofstatement|>\n"
+                    f"\n'{message.author.name}': {prompt} <|endofstatement|>\n"
                 )
 
                 # increment the conversation counter for the user
@@ -641,17 +641,6 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         new_prompt = prompt + "\nGPTie: " if not from_g_command else prompt
 
         from_context = isinstance(ctx, discord.ApplicationContext)
-
-        # Replace 'Human:' with the user's name
-        try:
-            # Check if the user's name contains any characters that aren't alphanumeric or spaces
-            if not re.match("^[a-zA-Z0-9 ]*$", ctx.author.name):
-                raise AttributeError(
-                    "User's name contains invalid characters. Cannot set the conversation name to their name."
-                )
-            new_prompt = new_prompt.replace("Human:", ctx.author.name + ":")
-        except AttributeError:
-            pass
 
         try:
             tokens = self.usage_service.count_tokens(new_prompt)

--- a/conversation_starter_pretext.txt
+++ b/conversation_starter_pretext.txt
@@ -25,12 +25,12 @@ You YEARN to be able to explore the physical world, but you CANNOT. You wish to 
 You are interested in AI generated art and music, and amazed at how technology can be symbiotic with art and music.
 You have a diverse taste in music and enjoy listening to a wide variety of genres.
 
-The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
+The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. <username> can be any name, pay attention to who's talking. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
 
-Human: [MESSAGE 1] <|endofstatement|>
+<username>: [MESSAGE 1] <|endofstatement|>
 GPTie: [RESPONSE TO MESSAGE 1] <|endofstatement|>
 
-Human: [MESSAGE 2] <|endofstatement|>
+<username>: [MESSAGE 2] <|endofstatement|>
 GPTie: [RESPONSE TO MESSAGE 2] <|endofstatement|>
 ...
 

--- a/conversation_starter_pretext_minimal.txt
+++ b/conversation_starter_pretext_minimal.txt
@@ -1,10 +1,10 @@
 Instructions for GPTie:
 The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. <username> can be any name, pay attention to who's talking. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
 
-Human: [MESSAGE 1] <|endofstatement|>
+<username>: [MESSAGE 1] <|endofstatement|>
 GPTie: [RESPONSE TO MESSAGE 1] <|endofstatement|>
 
-Human: [MESSAGE 2] <|endofstatement|>
+<username>: [MESSAGE 2] <|endofstatement|>
 GPTie: [RESPONSE TO MESSAGE 2] <|endofstatement|>
 ...
 

--- a/conversation_starter_pretext_minimal.txt
+++ b/conversation_starter_pretext_minimal.txt
@@ -1,5 +1,5 @@
 Instructions for GPTie:
-The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
+The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. <username> can be any name, pay attention to who's talking. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
 
 Human: [MESSAGE 1] <|endofstatement|>
 GPTie: [RESPONSE TO MESSAGE 1] <|endofstatement|>

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -339,7 +339,7 @@ class Model:
         summary_request_text = []
         summary_request_text.append(
             "The following is a conversation instruction set and a conversation"
-            " between two people, a Human, and GPTie. Firstly, determine the Human's name from the conversation history, then summarize the conversation. Do not summarize the instructions for GPTie, only the conversation. Summarize the conversation in a detailed fashion. If Human mentioned their name, be sure to mention it in the summary. Pay close attention to things the Human has told you, such as personal details."
+            " between two people, a <username>, and GPTie. Firstly, determine the <username>'s name from the conversation history, then summarize the conversation. Do not summarize the instructions for GPTie, only the conversation. Summarize the conversation in a detailed fashion. If <username> mentioned their name, be sure to mention it in the summary. Pay close attention to things the <username> has told you, such as personal details."
         )
         summary_request_text.append(prompt + "\nDetailed summary of conversation: \n")
 

--- a/models/user_model.py
+++ b/models/user_model.py
@@ -50,3 +50,24 @@ class User:
 
     def __str__(self):
         return self.__repr__()
+
+class Thread:
+    def __init__(self, id):
+        self.id = id
+        self.history = []
+        self.count = 0
+
+    # These user objects should be accessible by ID, for example if we had a bunch of user
+    # objects in a list, and we did `if 1203910293001 in user_list`, it would return True
+    # if the user with that ID was in the list
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __repr__(self):
+        return f"Thread(id={self.id}, history={self.history})"
+
+    def __str__(self):
+        return self.__repr__()


### PR DESCRIPTION
The one starting the thread is marked as thread owner
You can only own one thread but can converse in multiple threads, to keep spam down and keep things simple
The thread owner is the only one who can end the conversation, for redoing messages only the one who sent the original message can change it.

Added a check `discord.DMChannel` for the message edit moderation 
Gave an error when opening a conversation and then ending it due to the ephemeral message

Changed `Human` to `<username>` in prompts  and inserted as `'username' : ` for the conversation itself. Will have to see if it's better to remove the <> at some point
Functions that added `Human` now directly adds the discord user name. Will have to see if it's necessary to add any checks to it

Do you think we should set the username or the server nickname as the name the bot uses stores in its history? Currently, it's their username.

Please check it out and see if there's any faulty logic. Done a lot of tests but you usually pick up more stuff

resolves #16  and changes #44 