### PR TITLE
Add parameter overrides to opener files using json

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The Moderations service still uses the main API key defined in the `.env` file. 
 
 [**GPT3Discord Guides**](https://github.com/Kav-K/GPT3Discord/tree/main/detailed_guides)
 
-If you follow the link above, you will now get to detailed step-by-step guides that will help you to install and set up your GPT3Discord bot quickly and easily. If you still run into problems or have suggestions for improving the guides, you can join the [**Discord-Server**](https://discord.gg/WvAHXDMS7Q) and we try will help you. Keep in mind that the maintainers are volunteers and will try to help you on their schedule.
+If you follow the link above, you will now get to detailed step-by-step guides that will help you to install and set up your GPT3Discord bot quickly and easily. If you still run into problems or have suggestions for improving the guides, you can join the [**Discord-Server**](https://discord.gg/WvAHXDMS7Q) and we try to help you. Keep in mind that the maintainers are volunteers and will try to help you on their schedule.
 
 *The number and content of the guides is constantly adapted to current requirements.*
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The Moderations service still uses the main API key defined in the `.env` file. 
 
 [**GPT3Discord Guides**](https://github.com/Kav-K/GPT3Discord/tree/main/detailed_guides)
 
-If you follow the link above, you will now get to detailed step-by-step guides that will help you to install and set up your GPT3Discord bot quickly and easily. If you still run into problems or have suggestions for improving the guides, you can join the [**Discord-Server**](https://discord.gg/WvAHXDMS7Q) and we try to help you. Keep in mind that the maintainers are volunteers and will try to help you on their schedule.
+If you follow the link above, you will now get to detailed step-by-step guides that will help you to install and set up your GPT3Discord bot quickly and easily. If you still run into problems or have suggestions for improving the guides, you can join the [**Discord-Server**](https://discord.gg/WvAHXDMS7Q) and we will try to help you. Keep in mind that the maintainers are volunteers and will try to help you on their schedule.
 
 *The number and content of the guides is constantly adapted to current requirements.*
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ These commands are grouped, so each group has a prefix but you can easily tab co
 
 - Custom openers need to be placed as a .txt file in the `openers` directory, in the same directory as `gpt3discord.py`
 
+- Can use files in the `{"text": your prompt, "temp":0, "top_p":0,"frequency_penalty":0,"presence_penalty":0}` format to include permanent overrides
+
 `/gpt converse minimal:yes` - Start a conversation with the bot, like ChatGPT, with minimal context (saves tokens)
 
 - Note that the above options for `/gpt converse` can be combined (you can combine minimal, private, and opener!)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ These commands are grouped, so each group has a prefix but you can easily tab co
 
 - Custom openers need to be placed as a .txt file in the `openers` directory, in the same directory as `gpt3discord.py`
 
-- Can use files in the `{"text": your prompt, "temp":0, "top_p":0,"frequency_penalty":0,"presence_penalty":0}` format to include permanent overrides
+- Can use .json files in the `{"text": your prompt, "temp":0, "top_p":0,"frequency_penalty":0,"presence_penalty":0}` format to include permanent overrides
 
 `/gpt converse minimal:yes` - Start a conversation with the bot, like ChatGPT, with minimal context (saves tokens)
 

--- a/cogs/gpt_3_commands_and_converser.py
+++ b/cogs/gpt_3_commands_and_converser.py
@@ -1326,10 +1326,14 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             ):  # only load in files if it's included in the command, if not pass on as normal
                 if opener_file.endswith(".txt"):
                     # Load the file and read it into opener
-                    opener_file = EnvService.find_shared_file(
-                        f"openers{separator}{opener_file}"
-                    )
-                    opener_file = await self.load_file(opener_file, ctx)
+                    try:
+                        opener_file = EnvService.find_shared_file(
+                            f"openers{separator}{opener_file}"
+                        )
+                        opener_file = await self.load_file(opener_file, ctx)
+                    except ValueError as e:
+                        await ctx.respond("Error loading the file, "+ str(e),ephemeral=True, delete_after=180)
+                        return
                     if (
                         not opener
                     ):  # if we only use opener_file then only pass on opener_file for the opening prompt

--- a/cogs/gpt_3_commands_and_converser.py
+++ b/cogs/gpt_3_commands_and_converser.py
@@ -1314,37 +1314,6 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             )
             return
 
-        if opener:
-            opener = await self.mention_to_username(ctx, opener)
-
-        if not opener and not opener_file:
-            user_id_normalized = user.id
-        else:
-            user_id_normalized = ctx.author.id
-            if (
-                opener_file
-            ):  # only load in files if it's included in the command, if not pass on as normal
-                if opener_file.endswith(".txt"):
-                    # Load the file and read it into opener
-                    try:
-                        opener_file = EnvService.find_shared_file(
-                            f"openers{separator}{opener_file}"
-                        )
-                        opener_file = await self.load_file(opener_file, ctx)
-                    except ValueError as e:
-                        await ctx.respond("Error loading the file, "+ str(e),ephemeral=True, delete_after=180)
-                        return
-                    if (
-                        not opener
-                    ):  # if we only use opener_file then only pass on opener_file for the opening prompt
-                        opener = opener_file
-                    else:
-                        opener = opener_file + opener
-                    if not opener_file:
-                        return
-            else:
-                pass
-
         if private:
             await ctx.respond(user.name + "'s private conversation with GPT3")
             thread = await ctx.channel.create_thread(
@@ -1361,6 +1330,9 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             )
 
         self.conversation_threads[thread.id] = Thread(thread.id)
+
+        if opener:
+            opener = await self.mention_to_username(ctx, opener)
 
         if not opener and not opener_file:
             user_id_normalized = user.id

--- a/cogs/gpt_3_commands_and_converser.py
+++ b/cogs/gpt_3_commands_and_converser.py
@@ -1286,15 +1286,15 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                         opener_file = await self.load_file(opener_file, ctx)
                         try: # Try opening as json, if it fails it'll do it as a str
                             opener_file = json.loads(opener_file)
-                            temperature=None if not opener_file["temperature"] else opener_file["temperature"]
-                            top_p=None if not opener_file["top_p"] else opener_file["top_p"]
-                            frequency_penalty=None if not opener_file["frequency_penalty"] else opener_file["frequency_penalty"]
-                            presence_penalty=None if not opener_file["presence_penalty"] else opener_file["presence_penalty"]
+                            temperature=opener_file.get("temperature", None)
+                            top_p=opener_file.get("top_p", None)
+                            frequency_penalty=opener_file.get("frequency_penalty", None)
+                            presence_penalty=opener_file.get("presence_penalty", None)
                             self.conversation_threads[thread.id].set_overrides(temperature, top_p, frequency_penalty, presence_penalty) # set overrides
                             if not opener:  # if we only use opener_file then only pass on opener_file for the opening prompt
-                                opener = opener_file["text"]
+                                opener = opener_file.get('text', "error getting text")
                             else:
-                                opener = opener_file["text"] + opener
+                                opener = opener_file.get('text', "error getting text") + opener
                         except: # Parse as just regular text
                             if not opener: 
                                 opener = opener_file
@@ -1328,7 +1328,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
 
         # send opening
         if opener:
-            thread_message = await thread.send("***Opening prompt*** \n" + opener)
+            thread_message = await thread.send("***Opening prompt*** \n" + str(opener))
             if thread.id in self.conversation_threads:
                 self.awaiting_responses.append(user_id_normalized)
                 self.awaiting_thread_responses.append(thread.id)

--- a/cogs/gpt_3_commands_and_converser.py
+++ b/cogs/gpt_3_commands_and_converser.py
@@ -1275,7 +1275,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                 pass
             else: 
                 if not opener_file.endswith((".txt", ".json")):
-                    opener_file = None
+                    opener_file = None # Just start a regular thread if the file fails to load
                 else:
                     # Load the file and read it into opener
                     try:
@@ -1284,13 +1284,13 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                             f"openers{separator}{opener_file}"
                         )
                         opener_file = await self.load_file(opener_file, ctx)
-                        try: # Try opening as json, if it fails it'll do it as a str
+                        try: # Try opening as json, if it fails it'll just pass the whole txt or json to the opener
                             opener_file = json.loads(opener_file)
                             temperature=opener_file.get("temperature", None)
                             top_p=opener_file.get("top_p", None)
                             frequency_penalty=opener_file.get("frequency_penalty", None)
                             presence_penalty=opener_file.get("presence_penalty", None)
-                            self.conversation_threads[thread.id].set_overrides(temperature, top_p, frequency_penalty, presence_penalty) # set overrides
+                            self.conversation_threads[thread.id].set_overrides(temperature, top_p, frequency_penalty, presence_penalty)
                             if not opener:  # if we only use opener_file then only pass on opener_file for the opening prompt
                                 opener = opener_file.get('text', "error getting text")
                             else:
@@ -1301,7 +1301,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                             else:
                                 opener = opener_file + opener   
                     except:
-                        opener_file = None
+                        opener_file = None # Just start a regular thread if the file fails to load
                 
 
         # Append the starter text for gpt3 to the user's history so it gets concatenated with the prompt later
@@ -1314,7 +1314,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                 self.CONVERSATION_STARTER_TEXT
             )
 
-        # Set user as owner before sending anything that can error and leave the thread unowned
+        # Set user as thread owner before sending anything that can error and leave the thread unowned
         self.conversation_thread_owners[user_id_normalized] = thread.id
         overrides = self.conversation_threads[thread.id].get_overrides()
 

--- a/gpt3discord.py
+++ b/gpt3discord.py
@@ -24,7 +24,7 @@ from models.openai_model import Model
 from models.usage_service_model import UsageService
 from models.env_service_model import EnvService
 
-__version__ = "5.2"
+__version__ = "5.3"
 
 """
 The pinecone service is used to store and retrieve conversation embeddings.

--- a/models/user_model.py
+++ b/models/user_model.py
@@ -71,7 +71,7 @@ class Thread:
     def get_overrides(self):
         return {
             "temperature": self.temperature,
-            "top_p": self.temperature,
+            "top_p": self.top_p,
             "frequency_penalty": self.frequency_penalty,
             "presence_penalty": self.presence_penalty,
         }

--- a/models/user_model.py
+++ b/models/user_model.py
@@ -57,6 +57,24 @@ class Thread:
         self.id = id
         self.history = []
         self.count = 0
+        self.temperature = None
+        self.top_p = None
+        self.frequency_penalty = None
+        self.presence_penalty = None
+
+    def set_overrides(self, temperature=None,top_p=None,frequency_penalty=None,presence_penalty=None):
+        self.temperature = temperature
+        self.top_p = top_p
+        self.frequency_penalty = frequency_penalty
+        self.presence_penalty = presence_penalty
+
+    def get_overrides(self):
+        return {
+            "temperature": self.temperature,
+            "top_p": self.temperature,
+            "frequency_penalty": self.frequency_penalty,
+            "presence_penalty": self.presence_penalty,
+        }
 
     # These user objects should be accessible by ID, for example if we had a bunch of user
     # objects in a list, and we did `if 1203910293001 in user_list`, it would return True

--- a/openers/english_translator.json
+++ b/openers/english_translator.json
@@ -1,0 +1,8 @@
+{
+    "text":"I want you to act as an English translator, spelling corrector and improver. I will speak to you in any language and you will detect the language, translate it and answer in the corrected and improved version of my text, in English. I want you to replace my simplified A0-level words and sentences with more beautiful and elegant, upper level English words and sentences. Keep the meaning same, but make them more literary. I want you to only reply the correction, the improvements and nothing else, do not write explanations. ",
+    "temperature":0.77,
+    "top_p":0.9,
+    "frequency_penalty":0.95,
+    "presence_penalty":0.95
+}
+


### PR DESCRIPTION
Added the ability to load .json files which include temp, top p, frequency and presence penalties. Also fixed some path traversal possibilities with opener files. Reordered the parts of `/gpt converse` some too. A review and sanity check that the path traversal isn't possible anymore would be appreciated


In reference to discussion started by @uberdude420