### PR TITLE
Add support for CHAT_BYPASS_ROLES in Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ There are two thresholds for the bot, there are instances in which the bot will 
 
 If you'd like to help us test and fine tune our thresholds for the moderation service, please join this test server: https://discord.gg/CWhsSgNdrP. You can let off some steam in a controlled environment ;)
 
+To set a certain role immune to moderations, add the line `CHAT_BYPASS_ROLES="Role1,Role2,etc"` to your `.env file.
+
 **The above server is NOT for support or discussions about GPT3Discord**
 
 # Permanent Memory and Conversations

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -523,13 +523,16 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             and message.guild.id in Moderation.moderation_queues
             and Moderation.moderation_queues[message.guild.id] is not None
         ):
-            # Create a timestamp that is 0.5 seconds from now
-            timestamp = (
-                datetime.datetime.now() + datetime.timedelta(seconds=0.5)
-            ).timestamp()
-            await Moderation.moderation_queues[message.guild.id].put(
-                Moderation(message, timestamp)
-            )  # TODO Don't proceed to conversation processing if the message is deleted by moderations.
+            # Verify that the user is not in a role that can bypass moderation
+            if (CHAT_BYPASS_ROLES is not [None]
+            and message.author.roles is not in CHAT_BYPASS_ROLES):
+                # Create a timestamp that is 0.5 seconds from now
+                timestamp = (
+                    datetime.datetime.now() + datetime.timedelta(seconds=0.5)
+                ).timestamp()
+                await Moderation.moderation_queues[message.guild.id].put(
+                    Moderation(message, timestamp)
+                )  # TODO Don't proceed to conversation processing if the message is deleted by moderations.
 
         # Process the message if the user is in a conversation
         if await TextService.process_conversation_message(

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -524,9 +524,8 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             and message.guild.id in Moderation.moderation_queues
             and Moderation.moderation_queues[message.guild.id] is not None
         ):
-            print("The chat bypass roles are " + str(CHAT_BYPASS_ROLES))
             # Verify that the user is not in a role that can bypass moderation
-            if CHAT_BYPASS_ROLES is [None] or any(role.name.lower() in CHAT_BYPASS_ROLES for role in message.author.roles):
+            if CHAT_BYPASS_ROLES is [None] or not any(role.name.lower() in CHAT_BYPASS_ROLES for role in message.author.roles):
                 # Create a timestamp that is 0.5 seconds from now
                 timestamp = (
                     datetime.datetime.now() + datetime.timedelta(seconds=0.5)

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -524,8 +524,9 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             and message.guild.id in Moderation.moderation_queues
             and Moderation.moderation_queues[message.guild.id] is not None
         ):
+            print("The chat bypass roles are " + str(CHAT_BYPASS_ROLES))
             # Verify that the user is not in a role that can bypass moderation
-            if CHAT_BYPASS_ROLES is [None] or message.author.roles not in CHAT_BYPASS_ROLES:
+            if CHAT_BYPASS_ROLES is [None] or any(role.name.lower() in CHAT_BYPASS_ROLES for role in message.author.roles):
                 # Create a timestamp that is 0.5 seconds from now
                 timestamp = (
                     datetime.datetime.now() + datetime.timedelta(seconds=0.5)

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -31,6 +31,7 @@ else:
 #
 USER_INPUT_API_KEYS = EnvService.get_user_input_api_keys()
 USER_KEY_DB = EnvService.get_api_db()
+CHAT_BYPASS_ROLES = EnvService.get_bypass_roles()
 
 #
 # Obtain the Moderation table and the General table, these are two SQLite tables that contain
@@ -524,8 +525,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             and Moderation.moderation_queues[message.guild.id] is not None
         ):
             # Verify that the user is not in a role that can bypass moderation
-            if (CHAT_BYPASS_ROLES is not [None]
-            and message.author.roles is not in CHAT_BYPASS_ROLES):
+            if CHAT_BYPASS_ROLES is [None] or message.author.roles not in CHAT_BYPASS_ROLES:
                 # Create a timestamp that is 0.5 seconds from now
                 timestamp = (
                     datetime.datetime.now() + datetime.timedelta(seconds=0.5)

--- a/gpt3discord.py
+++ b/gpt3discord.py
@@ -27,7 +27,7 @@ from services.environment_service import EnvService
 from models.openai_model import Model
 
 
-__version__ = "8.1.3"
+__version__ = "8.2"
 
 
 if sys.platform == "win32":

--- a/services/environment_service.py
+++ b/services/environment_service.py
@@ -269,6 +269,32 @@ class EnvService:
         return user_key_db
 
     @staticmethod
+    def get_bypass_roles():
+        # GPT_ROLES is a comma separated list of string roles
+        # It can also just be one role
+        # Read these allowed roles and return as a list of strings
+        try:
+            bypass_roles = os.getenv("CHAT_BYPASS_ROLES")
+        except Exception:
+            bypass_roles = None
+
+        if bypass_roles is None:
+            print(
+                "CHAT_BYPASS_ROLES is not defined properly in the environment file!"
+                "Please copy your server's role and put it into CHAT_BYPASS_ROLES in the .env file."
+                'For example a line should look like: `CHAT_BYPASS_ROLES="bypass"`'
+            )
+            print("Defaulting to allowing NO ONE to bypass chat moderation")
+            return [None]
+
+        bypass_roles = (
+            bypass_roles.lower().strip().split(",")
+            if "," in bypass_roles
+            else [bypass_roles.lower()]
+        )
+        return bypass_roles
+
+    @staticmethod
     def get_deepl_token():
         try:
             deepl_token = os.getenv("DEEPL_TOKEN")

--- a/services/moderations_service.py
+++ b/services/moderations_service.py
@@ -158,32 +158,7 @@ class Moderation:
         if warn_result:
             return ModerationResult.WARN
         return ModerationResult.NONE
-    
-    @staticmethod
-    def get_bypass_roles():
-        # GPT_ROLES is a comma separated list of string roles
-        # It can also just be one role
-        # Read these allowed roles and return as a list of strings
-        try:
-            bypass_roles = os.getenv("CHAT_BYPASS_ROLES")
-        except Exception:
-            bypass_roles = None
 
-        if bypass_roles is None:
-            print(
-                "CHAT_BYPASS_ROLES is not defined properly in the environment file!"
-                "Please copy your server's role and put it into CHAT_BYPASS_ROLES in the .env file."
-                'For example a line should look like: `CHAT_BYPASS_ROLES="bypass"`'
-            )
-            print("Defaulting to allowing NO ONE to bypass chat moderation")
-            return [None]
-
-        bypass_roles = (
-            bypass_roles.lower().strip().split(",")
-            if "," in bypass_roles
-            else [bypass_roles.lower()]
-        )
-        return bypass_roles
     # This function will be called by the bot to process the message queue
     @staticmethod
     async def process_moderation_queue(

--- a/services/moderations_service.py
+++ b/services/moderations_service.py
@@ -158,7 +158,32 @@ class Moderation:
         if warn_result:
             return ModerationResult.WARN
         return ModerationResult.NONE
+    
+    @staticmethod
+    def get_bypass_roles():
+        # GPT_ROLES is a comma separated list of string roles
+        # It can also just be one role
+        # Read these allowed roles and return as a list of strings
+        try:
+            bypass_roles = os.getenv("CHAT_BYPASS_ROLES")
+        except Exception:
+            bypass_roles = None
 
+        if bypass_roles is None:
+            print(
+                "CHAT_BYPASS_ROLES is not defined properly in the environment file!"
+                "Please copy your server's role and put it into CHAT_BYPASS_ROLES in the .env file."
+                'For example a line should look like: `CHAT_BYPASS_ROLES="bypass"`'
+            )
+            print("Defaulting to allowing NO ONE to bypass chat moderation")
+            return [None]
+
+        bypass_roles = (
+            bypass_roles.lower().strip().split(",")
+            if "," in bypass_roles
+            else [bypass_roles.lower()]
+        )
+        return bypass_roles
     # This function will be called by the bot to process the message queue
     @staticmethod
     async def process_moderation_queue(

--- a/services/text_service.py
+++ b/services/text_service.py
@@ -9,9 +9,6 @@ from discord.ext import pages
 from services.deletion_service import Deletion
 from models.openai_model import Model
 from models.user_model import EmbeddedConversationItem, RedoUser
-
-CHAT_BYPASS_ROLES = EnvService.get_bypass_roles()
-
 class TextService:
     def __init__(self):
         pass

--- a/services/text_service.py
+++ b/services/text_service.py
@@ -10,6 +10,7 @@ from services.deletion_service import Deletion
 from models.openai_model import Model
 from models.user_model import EmbeddedConversationItem, RedoUser
 
+CHAT_BYPASS_ROLES = EnvService.get_bypass_roles()
 
 class TextService:
     def __init__(self):


### PR DESCRIPTION
Adds a check for CHAT_BYPASS_ROLES in the environment file to allow specific roles to bypass the automoderation service when enabled. 
