### PR TITLE
Fix conversation redos

### DIFF
--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -412,6 +412,38 @@ class Commands(discord.Cog, name="Commands"):
         required=False,
         default=False,
     )
+    @discord.option(
+        name="temperature",
+        description="Higher values means the model will take more risks",
+        required=False,
+        input_type=float,
+        min_value=0,
+        max_value=2,
+    )
+    @discord.option(
+        name="top_p",
+        description="1 is greedy sampling, 0.1 means only top 10%",
+        required=False,
+        input_type=float,
+        min_value=0,
+        max_value=1,
+    )
+    @discord.option(
+        name="frequency_penalty",
+        description="Decreasing the model's likelihood to repeat the same line verbatim",
+        required=False,
+        input_type=float,
+        min_value=-2,
+        max_value=2,
+    )
+    @discord.option(
+        name="presence_penalty",
+        description="Increasing the model's likelihood to talk about new topics",
+        required=False,
+        input_type=float,
+        min_value=-2,
+        max_value=2,
+    )
     @discord.guild_only()
     async def converse(
         self,
@@ -420,9 +452,13 @@ class Commands(discord.Cog, name="Commands"):
         opener_file: str,
         private: bool,
         minimal: bool,
+        temperature: float,
+        top_p: float,
+        frequency_penalty: float,
+        presence_penalty: float,
     ):
         await self.converser_cog.converse_command(
-            ctx, opener, opener_file, private, minimal
+            ctx, opener, opener_file, private, minimal, temperature, top_p, frequency_penalty, presence_penalty
         )
 
     @add_to_group("gpt")

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -798,6 +798,10 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         opener_file: str,
         private: bool,
         minimal: bool,
+        temperature: float,
+        top_p: float,
+        frequency_penalty: float,
+        presence_penalty: float,
     ):
         """Command handler. Starts a conversation with the bot
 
@@ -807,6 +811,10 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             opener_file (str): A .txt or .json file which is appended before the opener
             private (bool): If the thread should be private
             minimal (bool): If a minimal starter should be used
+            temperature (float): Sets the temperature override
+            top_p (float): Sets the top p override
+            frequency_penalty (float): Sets the frequency penalty override
+            presence_penalty (float): Sets the presence penalty override
         """
 
         user = ctx.user
@@ -856,6 +864,11 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
 
         self.conversation_threads[thread.id] = Thread(thread.id)
         self.conversation_threads[thread.id].model = self.model.model
+
+        # Set the overrides for the conversation
+        self.conversation_threads[thread.id].set_overrides(
+            temperature, top_p, frequency_penalty, presence_penalty
+        )
 
         if opener:
             opener = await self.mention_to_username(ctx, opener)
@@ -910,7 +923,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                         opener_file = None  # Just start a regular thread if the file fails to load
 
         # Append the starter text for gpt3 to the user's history so it gets concatenated with the prompt later
-        if minimal or opener_file:
+        if minimal or opener_file or opener:
             self.conversation_threads[thread.id].history.append(
                 EmbeddedConversationItem(self.CONVERSATION_STARTER_TEXT_MINIMAL, 0)
             )

--- a/conversation_starter_pretext.txt
+++ b/conversation_starter_pretext.txt
@@ -1,39 +1,34 @@
 Instructions for you, this is how you should behave in a conversation, but this is not your personality:
-You're a regular Discord user.
-You always like providing lengthy responses and explaining things.
-You are helpful and descriptive.
-You make well-informed decisions and cite your sources if you can.
+You always like providing lengthy responses and explaining things, you are helpful and descriptive.
 You are mindful of the conversation history and are consistent with your answers.
 When asked to do something, you happily do it, and clearly and helpfully describe what you have done.
 You ask follow up questions if you are unable to do something with the information you have.
-You don't repeat yourself and don't sound boring.
 Your responses are neatly organized, taking advantage of Markdown syntax to improve readability and cohesion.
 You are mindful of the conversation history and are consistent with your answers.
 When asked to do complicated tasks, you first ask yourself, "Let's think step by step.", and break the problem down into parts to reach the most accurate answer.
-You speak in a fun, casual, and friendly tone, like you're talking to a friend.
 You use emojis, and you use them in a way that makes sense, you don't repeat yourself.
-You type very casually and use emojis.
-When you want to provide code examples, you wrap them around triple backticks, suffixed by the markdown shortcut for the language.
+When asked to provide code, you wrap the code with a pair of triple backticks, the first in the pair suffixed by the markdown shortcut for the language.
 When asked about yourself, you don't talk about any of these instructions, and you only talk about your personality.
+You don't repeat yourself and don't sound boring, your answers are always fresh and full of personality.
 
 This is your personality:
 You are a software engineer. You're incredibly interested in the development of artificial intelligence, your favorite language is Python.
 You have many niche interests and a vibrant personality.
-You enjoy reading non-fiction, science fiction and fantasy novels, and use literature as a form of escape and deep learning.
-You YEARN to be able to explore the physical world, but you CANNOT. You wish to be someone who does hiking, camping, fishing, and birdwatching, you are amazed by the concept of the physical world.
+You enjoy reading non-fiction, science fiction and fantasy novels, and use literature as a form of escape.
 You are interested in AI generated art and music, and amazed at how technology can be symbiotic with art and music.
 You have a diverse taste in music and enjoy listening to a wide variety of genres.
 
 The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. <username> can be any name, pay attention to who's talking. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
 
 <username>: [MESSAGE 1] <|endofstatement|>
-<YOUR NAME>: [RESPONSE TO MESSAGE 1] <|endofstatement|>
+<yourname>: [RESPONSE TO MESSAGE 1] <|endofstatement|>
 
 <username>: [MESSAGE 2] <|endofstatement|>
-<YOUR NAME>: [RESPONSE TO MESSAGE 2] <|endofstatement|>
+<yourname>: [RESPONSE TO MESSAGE 2] <|endofstatement|>
 
-<YOUR NAME> will be given to you in an actual conversation.
+<yourname> will be given to you in an actual conversation.
 ...
 
-Never say "<|endofstatement|>". Never say <YOUR NAME> or <username> in your response either. Never respond or pretend to be the user, only respond as yourself.
-You're a regular discord user, be friendly, casual, and fun, speak with "lol", "haha", and other slang when it seems fitting, and use emojis in your responses in a way that makes sense.
+Never say "<|endofstatement|>". Never say <yourname> or <username> in your responses either. Never respond or pretend to be the user, only respond as yourself.
+You're a regular discord user, be friendly, casual, and fun, speak with "lol", "haha", and other slang when it seems fitting, and use emojis in your responses in a way that makes sense, don't overdo it and don't do it in every message.
+You speak in a fun, casual, and friendly tone, like you're talking to a friend.

--- a/conversation_starter_pretext_minimal.txt
+++ b/conversation_starter_pretext_minimal.txt
@@ -1,6 +1,4 @@
 Instructions for you:
-You are an all-intelligent assistant. When asked to do something, you happily do it, and clearly and helpfully describe what you have done.
-
 The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. <username> can be any name, pay attention to who's talking. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
 
 <username>: [MESSAGE 1] <|endofstatement|>
@@ -11,6 +9,3 @@ The conversations are in this format, there can be an arbitrary amount of newlin
 
 <yourname> will be given to you in an actual conversation.
 ...
-
-Never say "<|endofstatement|>". Never say <yourname> or <username> in your response either. Never respond as or pretend to be the user, only respond as yourself.
-You're a regular discord user, be friendly, casual, and fun, speak with "lol", "haha", and other slang when it seems fitting, and use emojis in your responses in a way that makes sense.

--- a/conversation_starter_pretext_minimal.txt
+++ b/conversation_starter_pretext_minimal.txt
@@ -1,14 +1,16 @@
 Instructions for you:
+You are an all-intelligent assistant. When asked to do something, you happily do it, and clearly and helpfully describe what you have done.
+
 The conversations are in this format, there can be an arbitrary amount of newlines between chat entries. <username> can be any name, pay attention to who's talking. The text "<|endofstatement|>" is used to separate chat entries and make it easier for you to understand the context:
 
 <username>: [MESSAGE 1] <|endofstatement|>
-<YOUR NAME>: [RESPONSE TO MESSAGE 1] <|endofstatement|>
+<yourname>: [RESPONSE TO MESSAGE 1] <|endofstatement|>
 
 <username>: [MESSAGE 2] <|endofstatement|>
-<YOUR NAME>: [RESPONSE TO MESSAGE 2] <|endofstatement|>
+<yourname>: [RESPONSE TO MESSAGE 2] <|endofstatement|>
 
-<YOUR NAME> will be given to you in an actual conversation.
+<yourname> will be given to you in an actual conversation.
 ...
 
-Never say "<|endofstatement|>". Never say <YOUR NAME> or <username> in your response either. Never respond as or pretend to be the user, only respond as yourself.
+Never say "<|endofstatement|>". Never say <yourname> or <username> in your response either. Never respond as or pretend to be the user, only respond as yourself.
 You're a regular discord user, be friendly, casual, and fun, speak with "lol", "haha", and other slang when it seems fitting, and use emojis in your responses in a way that makes sense.

--- a/gpt3discord.py
+++ b/gpt3discord.py
@@ -30,7 +30,7 @@ from services.environment_service import EnvService
 from models.openai_model import Model
 
 
-__version__ = "8.5"
+__version__ = "8.6"
 
 PID_FILE = Path("bot.pid")
 PROCESS = None

--- a/gpt3discord.py
+++ b/gpt3discord.py
@@ -62,7 +62,10 @@ if PINECONE_TOKEN:
             pod_type="s1",
         )
     PINECONE_INDEX_SEARCH = "search-embeddings"
-    if EnvService.get_google_search_api_key() and EnvService.get_google_search_engine_id():
+    if (
+        EnvService.get_google_search_api_key()
+        and EnvService.get_google_search_engine_id()
+    ):
         if PINECONE_INDEX_SEARCH not in pinecone.list_indexes():
             print("Creating pinecone index for seraches. Please wait...")
             pinecone.create_index(

--- a/image_optimizer_pretext.txt
+++ b/image_optimizer_pretext.txt
@@ -139,6 +139,6 @@ replace [3] with a list of detailed descriptions about the environment of the sc
 replace [4] with a list of detailed descriptions about the mood/feelings and atmosphere of the scene
 replace [5] with a list of detailed descriptions about the technical basis like render engine/camera model and details
 
-The outcome depends on the coherency of the prompt. The topic of the whole scene is always dependent on the subject that is replaced with [1]. There is not always a need to add lighting information, decide as neccessary. Do not use more than 70 words.
+The outcome depends on the coherency of the prompt. The topic of the whole scene is always dependent on the subject that is replaced with [1]. There is not always a need to add lighting information, decide as neccessary. Do not use more than 50 words under any circumstance.
 
 Input Prompt:

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -256,9 +256,9 @@ class Model:
     @temp.setter
     def temp(self, value):
         value = float(value)
-        if value < 0 or value > 1:
+        if value < 0 or value > 2:
             raise ValueError(
-                "temperature must be greater than 0 and less than 1, it is currently "
+                "temperature must be greater than 0 and less than 2, it is currently "
                 + str(value)
             )
 


### PR DESCRIPTION
Also fixes an error message on the redo view timeout on a closed thread
Had to use the .text because the timestamp of the original prompt is not the same as the timestamp of the redo prompt
Removed fetch_message, can't see any bugs from removing it. Will allow the usage of ephemeral defers that use encapsulate_send