### PR TITLE
Add the ability to set model in threads

### DIFF
--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -302,6 +302,11 @@ class Commands(discord.Cog, name="Commands"):
         name="prompt", description="The prompt to send to GPT3", required=True
     )
     @discord.option(
+        name="ephemeral", 
+        description="Will only be visible to you", 
+        required=False
+    )
+    @discord.option(
         name="temperature",
         description="Higher values means the model will take more risks",
         required=False,
@@ -334,13 +339,14 @@ class Commands(discord.Cog, name="Commands"):
         self,
         ctx: discord.ApplicationContext,
         prompt: str,
+        ephemeral: bool,
         temperature: float,
         top_p: float,
         frequency_penalty: float,
         presence_penalty: float,
     ):
         await self.converser_cog.ask_command(
-            ctx, prompt, temperature, top_p, frequency_penalty, presence_penalty
+            ctx, prompt, ephemeral, temperature, top_p, frequency_penalty, presence_penalty
         )
 
     @add_to_group("gpt")
@@ -359,6 +365,11 @@ class Commands(discord.Cog, name="Commands"):
         description="The text you want to edit, can be empty",
         required=False,
         default="",
+    )
+    @discord.option(
+        name="ephemeral", 
+        description="Will only be visible to you", 
+        required=False
     )
     @discord.option(
         name="temperature",
@@ -385,12 +396,13 @@ class Commands(discord.Cog, name="Commands"):
         ctx: discord.ApplicationContext,
         instruction: str,
         text: str,
+        ephemeral: bool,
         temperature: float,
         top_p: float,
         codex: bool,
     ):
         await self.converser_cog.edit_command(
-            ctx, instruction, text, temperature, top_p, codex
+            ctx, instruction, text, ephemeral, temperature, top_p, codex
         )
 
     @add_to_group("gpt")

--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -423,6 +423,13 @@ class Commands(discord.Cog, name="Commands"):
         default=False,
     )
     @discord.option(
+        name="model",
+        description="Which model to use with the bot",
+        required=False,
+        default=False,
+        autocomplete=Settings_autocompleter.get_models,
+    )
+    @discord.option(
         name="temperature",
         description="Higher values means the model will take more risks",
         required=False,
@@ -462,6 +469,7 @@ class Commands(discord.Cog, name="Commands"):
         opener_file: str,
         private: bool,
         minimal: bool,
+        model: str,
         temperature: float,
         top_p: float,
         frequency_penalty: float,
@@ -473,6 +481,7 @@ class Commands(discord.Cog, name="Commands"):
             opener_file,
             private,
             minimal,
+            model,
             temperature,
             top_p,
             frequency_penalty,

--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -302,7 +302,7 @@ class Commands(discord.Cog, name="Commands"):
         name="prompt", description="The prompt to send to GPT3", required=True
     )
     @discord.option(
-        name="ephemeral", 
+        name="private", 
         description="Will only be visible to you", 
         required=False
     )
@@ -339,14 +339,14 @@ class Commands(discord.Cog, name="Commands"):
         self,
         ctx: discord.ApplicationContext,
         prompt: str,
-        ephemeral: bool,
+        private: bool,
         temperature: float,
         top_p: float,
         frequency_penalty: float,
         presence_penalty: float,
     ):
         await self.converser_cog.ask_command(
-            ctx, prompt, ephemeral, temperature, top_p, frequency_penalty, presence_penalty
+            ctx, prompt, private, temperature, top_p, frequency_penalty, presence_penalty
         )
 
     @add_to_group("gpt")
@@ -367,7 +367,7 @@ class Commands(discord.Cog, name="Commands"):
         default="",
     )
     @discord.option(
-        name="ephemeral", 
+        name="private", 
         description="Will only be visible to you", 
         required=False
     )
@@ -396,13 +396,13 @@ class Commands(discord.Cog, name="Commands"):
         ctx: discord.ApplicationContext,
         instruction: str,
         text: str,
-        ephemeral: bool,
+        private: bool,
         temperature: float,
         top_p: float,
         codex: bool,
     ):
         await self.converser_cog.edit_command(
-            ctx, instruction, text, ephemeral, temperature, top_p, codex
+            ctx, instruction, text, private, temperature, top_p, codex
         )
 
     @add_to_group("gpt")

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -801,6 +801,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         opener_file: str,
         private: bool,
         minimal: bool,
+        model: str,
         temperature: float,
         top_p: float,
         frequency_penalty: float,
@@ -814,6 +815,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             opener_file (str): A .txt or .json file which is appended before the opener
             private (bool): If the thread should be private
             minimal (bool): If a minimal starter should be used
+            model (str): The openai model that should be used
             temperature (float): Sets the temperature override
             top_p (float): Sets the top p override
             frequency_penalty (float): Sets the frequency penalty override
@@ -866,7 +868,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             )
 
         self.conversation_threads[thread.id] = Thread(thread.id)
-        self.conversation_threads[thread.id].model = self.model.model
+        self.conversation_threads[thread.id].model = self.model.model if not model else model
 
         # Set the overrides for the conversation
         self.conversation_threads[thread.id].set_overrides(

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -693,6 +693,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         self,
         ctx: discord.ApplicationContext,
         prompt: str,
+        ephemeral: bool,
         temperature: float,
         top_p: float,
         frequency_penalty: float,
@@ -720,7 +721,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             if not user_api_key:
                 return
 
-        await ctx.defer()
+        await ctx.defer(ephemeral=ephemeral)
 
         overrides = Override(temperature, top_p, frequency_penalty, presence_penalty)
 
@@ -741,6 +742,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         ctx: discord.ApplicationContext,
         instruction: str,
         text: str,
+        ephemeral: bool,
         temperature: float,
         top_p: float,
         codex: bool,
@@ -766,7 +768,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             if not user_api_key:
                 return
 
-        await ctx.defer()
+        await ctx.defer(ephemeral=ephemeral)
 
         overrides = Override(temperature, top_p, 0, 0)
 

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -693,7 +693,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         self,
         ctx: discord.ApplicationContext,
         prompt: str,
-        ephemeral: bool,
+        private: bool,
         temperature: float,
         top_p: float,
         frequency_penalty: float,
@@ -721,7 +721,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             if not user_api_key:
                 return
 
-        await ctx.defer(ephemeral=ephemeral)
+        await ctx.defer(ephemeral=private)
 
         overrides = Override(temperature, top_p, frequency_penalty, presence_penalty)
 
@@ -742,7 +742,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         ctx: discord.ApplicationContext,
         instruction: str,
         text: str,
-        ephemeral: bool,
+        private: bool,
         temperature: float,
         top_p: float,
         codex: bool,
@@ -768,7 +768,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             if not user_api_key:
                 return
 
-        await ctx.defer(ephemeral=ephemeral)
+        await ctx.defer(ephemeral=private)
 
         overrides = Override(temperature, top_p, 0, 0)
 

--- a/gpt3discord.py
+++ b/gpt3discord.py
@@ -30,7 +30,7 @@ from services.environment_service import EnvService
 from models.openai_model import Model
 
 
-__version__ = "9.0.1"
+__version__ = "9.1"
 
 
 PID_FILE = Path("bot.pid")

--- a/models/autocomplete_model.py
+++ b/models/autocomplete_model.py
@@ -86,6 +86,17 @@ class Settings_autocompleter:
         await ctx.interaction.response.defer()  # defer so the autocomplete in int values doesn't error but rather just says not found
         return []
 
+    async def get_models(
+        ctx: discord.AutocompleteContext,
+    ):
+        """Gets all models"""
+        return [
+            value
+            for value in Models.TEXT_MODELS
+            if value.startswith(ctx.value.lower())
+        ]
+    
+    
     async def get_value_moderations(
         ctx: discord.AutocompleteContext,
     ):  # Behaves a bit weird if you go back and edit the parameter without typing in a new command

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -44,7 +44,6 @@ class Override:
 class Models:
     # Text models
     DAVINCI = "text-davinci-003"
-    DAVINCI_FT = "davinci:ft-personal-2023-01-28-08-02-00"
     CURIE = "text-curie-001"
     BABBAGE = "text-babbage-001"
     ADA = "text-ada-001"
@@ -61,7 +60,7 @@ class Models:
     CODE_EDIT = "code-davinci-edit-001"
 
     # Model collections
-    TEXT_MODELS = [DAVINCI, DAVINCI_FT,CURIE, BABBAGE, ADA, CODE_DAVINCI, CODE_CUSHMAN]
+    TEXT_MODELS = [DAVINCI, CURIE, BABBAGE, ADA, CODE_DAVINCI, CODE_CUSHMAN]
     EDIT_MODELS = [EDIT, CODE_EDIT]
 
     DEFAULT = DAVINCI
@@ -70,7 +69,6 @@ class Models:
     # Tokens Mapping
     TOKEN_MAPPING = {
         "text-davinci-003": 4024,
-        "davinci:ft-personal-2023-01-28-08-02-00": 4042,
         "text-curie-001": 2024,
         "text-babbage-001": 2024,
         "text-ada-001": 2024,

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -45,6 +45,7 @@ class Models:
     # Text models
     DAVINCI = "text-davinci-003"
     CURIE = "text-curie-001"
+    BABBAGES = "babbage"
     BABBAGE = "text-babbage-001"
     ADA = "text-ada-001"
 
@@ -60,7 +61,7 @@ class Models:
     CODE_EDIT = "code-davinci-edit-001"
 
     # Model collections
-    TEXT_MODELS = [DAVINCI, CURIE, BABBAGE, ADA, CODE_DAVINCI, CODE_CUSHMAN]
+    TEXT_MODELS = [DAVINCI, CURIE, BABBAGES, BABBAGE, ADA, CODE_DAVINCI, CODE_CUSHMAN]
     EDIT_MODELS = [EDIT, CODE_EDIT]
 
     DEFAULT = DAVINCI
@@ -78,7 +79,7 @@ class Models:
 
     @staticmethod
     def get_max_tokens(model: str) -> int:
-        return Models.TOKEN_MAPPING.get(model, 4024)
+        return Models.TOKEN_MAPPING.get(model, 2024)
 
 
 class ImageSize:
@@ -781,6 +782,10 @@ class Model:
                 f"Prompt must be greater than {self.prompt_min_length} characters, it is currently: {len(prompt)} characters"
             )
 
+        if not max_tokens_override:
+            if model:
+                max_tokens_override = Models.get_max_tokens(model) - tokens
+
         print(f"The prompt about to be sent is {prompt}")
         print(
             f"Overrides -> temp:{temp_override}, top_p:{top_p_override} frequency:{frequency_penalty_override}, presence:{presence_penalty_override}"
@@ -793,8 +798,8 @@ class Model:
                 "stop": "" if stop is None else stop,
                 "temperature": self.temp if temp_override is None else temp_override,
                 "top_p": self.top_p if top_p_override is None else top_p_override,
-                "max_tokens": self.max_tokens if not model else Models.get_max_tokens(model) - tokens
-                if not max_tokens_override
+                "max_tokens": self.max_tokens - tokens 
+                if max_tokens_override is None
                 else max_tokens_override,
                 "presence_penalty": self.presence_penalty
                 if presence_penalty_override is None

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -45,7 +45,6 @@ class Models:
     # Text models
     DAVINCI = "text-davinci-003"
     CURIE = "text-curie-001"
-    BABBAGES = "babbage"
     BABBAGE = "text-babbage-001"
     ADA = "text-ada-001"
 
@@ -61,7 +60,7 @@ class Models:
     CODE_EDIT = "code-davinci-edit-001"
 
     # Model collections
-    TEXT_MODELS = [DAVINCI, CURIE, BABBAGES, BABBAGE, ADA, CODE_DAVINCI, CODE_CUSHMAN]
+    TEXT_MODELS = [DAVINCI, CURIE, BABBAGE, ADA, CODE_DAVINCI, CODE_CUSHMAN]
     EDIT_MODELS = [EDIT, CODE_EDIT]
 
     DEFAULT = DAVINCI

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -44,6 +44,7 @@ class Override:
 class Models:
     # Text models
     DAVINCI = "text-davinci-003"
+    DAVINCI_FT = "davinci:ft-personal-2023-01-28-08-02-00"
     CURIE = "text-curie-001"
     BABBAGE = "text-babbage-001"
     ADA = "text-ada-001"
@@ -60,7 +61,7 @@ class Models:
     CODE_EDIT = "code-davinci-edit-001"
 
     # Model collections
-    TEXT_MODELS = [DAVINCI, CURIE, BABBAGE, ADA, CODE_DAVINCI, CODE_CUSHMAN]
+    TEXT_MODELS = [DAVINCI, DAVINCI_FT,CURIE, BABBAGE, ADA, CODE_DAVINCI, CODE_CUSHMAN]
     EDIT_MODELS = [EDIT, CODE_EDIT]
 
     DEFAULT = DAVINCI
@@ -69,6 +70,7 @@ class Models:
     # Tokens Mapping
     TOKEN_MAPPING = {
         "text-davinci-003": 4024,
+        "davinci:ft-personal-2023-01-28-08-02-00": 4042,
         "text-curie-001": 2024,
         "text-babbage-001": 2024,
         "text-ada-001": 2024,

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -584,7 +584,7 @@ class Model:
     def backoff_handler_request(details):
         print(
             f"Backing off {details['wait']:0.1f} seconds after {details['tries']} tries calling function {details['target']} | "
-            f"{details['exception'].args}"
+            f"{details['exception'].args[0]}"
         )
 
     async def valid_text_request(self, response):
@@ -657,7 +657,7 @@ class Model:
         )
         print(f"Overrides -> temp:{temp_override}, top_p:{top_p_override}")
 
-        async with aiohttp.ClientSession(raise_for_status=True) as session:
+        async with aiohttp.ClientSession(raise_for_status=False) as session:
             payload = {
                 "model": Models.EDIT if codex is False else Models.CODE_EDIT,
                 "input": "" if text is None else text,
@@ -724,7 +724,7 @@ class Model:
 
         tokens = self.usage_service.count_tokens(summary_request_text)
 
-        async with aiohttp.ClientSession(raise_for_status=True) as session:
+        async with aiohttp.ClientSession(raise_for_status=False) as session:
             payload = {
                 "model": Models.DAVINCI,
                 "prompt": summary_request_text,


### PR DESCRIPTION
Added option to set a model when opening a conversation thread, currently taken from `TEXT_MODELS`
Changed the backoff handler to use the `ValueError` where `valid_text_request` is used due to providing a more verbose error to the user
Reduced max tokens set if model can't be found in the list from 4024 to 2024, less prone to api errors 
Added ephemeral options to ask and edit

closes #125 I believe, should be able to type in the finetuned models name into the option when starting a conversation, or add it to the code to get it from the list. I haven't been able to test this since I don't have a finetuned model readily available