### PR TITLE
Add dependabot to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Let's have automation tell us when there are new action versions.
- It can also do pip - but we can add that in a seperate PR if there is interest ...

Right now we will get PRs once a week if there are new versions.

Test:
- Load with pyyaml to ensure valid yaml