### PR TITLE
Add pip (requirements) dependabot updating

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- Once a week dependabot will look at dependencies and open a PR per depdency as they upgrade
- This will ensure we don't get to far behind without knowing a reason (hopefully via CI) not to upgrade