### PR TITLE
Build Docker image with 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10"]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PY_VERSION=3.9
+ARG PY_VERSION=3.10
 
 # Build container
 FROM python:${PY_VERSION} as base


### PR DESCRIPTION
- Build via Python 3.10 in Docker
  - I originally tried python3.11 as there are lots of perf wins there but we have build errors I don't want to debug at this time
- Add CI to build with python3.10 on CI too

Test:
- Build it - `docker build --build-arg FULL=true -t gpt3discord .`
```
crl-m1:GPT3Discord cooper$ docker image ls
REPOSITORY                     TAG               IMAGE ID       CREATED          SIZE
gpt3discord                    latest            6cd5ff57745d   14 seconds ago   1.14GB
```
- This is an aarch64 build too
```
Darwin crl-m1.cooperlees.com 22.3.0 Darwin Kernel Version 22.3.0: Mon Jan 30 20:39:35 PST 2023; root:xnu-8792.81.3~2/RELEASE_ARM64_T8103 arm64
```