### PR TITLE
Fix split messages in conversations breaking conversation

### DIFF
--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -425,9 +425,10 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                 first = True
             else:
                 if from_context:
-                    await ctx.send_followup(chunk)
+                    response_message = await ctx.send_followup(chunk)
                 else:
-                    await ctx.channel.send(chunk)
+                    response_message = await ctx.channel.send(chunk)
+        return response_message
 
     async def paginate_embed(self, response_text, codex, prompt=None, instruction=None):
         """Given a response text make embed pages and return a list of the pages. Codex makes it a codeblock in the embed"""

--- a/services/text_service.py
+++ b/services/text_service.py
@@ -432,7 +432,7 @@ class TextService:
                 if len(response_text) > converser_cog.TEXT_CUTOFF:
                     if not from_context:
                         paginator = None
-                        await converser_cog.paginate_and_send(response_text, ctx)
+                        response_message = await converser_cog.paginate_and_send(response_text, ctx)
                     else:
                         embed_pages = await converser_cog.paginate_embed(
                             response_text, codex, prompt, instruction


### PR DESCRIPTION
I believe this fixes #203
I have not added the conversation view though possible, because the redo function doesn't account for what it's redoing being split into multiple messages. Can use pagination but it doesn't look nice in a conversation imo. Thoughts on doing it that way?

![image](https://user-images.githubusercontent.com/15952522/222712385-1fc394de-315d-4abb-8d59-990a11a31bee.png)
