### PR TITLE
Add arm64 to pr build

### DIFF
--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -218,8 +218,16 @@ jobs:
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
     steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 10
+
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
@@ -242,7 +250,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and push full Docker image
         id: build-and-push-full
@@ -255,4 +263,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Build amd64 and arm64 images together on pr, can be separated into an extra action if required.